### PR TITLE
Potentially fixes #19 with configurable changes to layout size resolution 

### DIFF
--- a/scratchoff-sample/build.gradle
+++ b/scratchoff-sample/build.gradle
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId "com.jackpocket.scratchoff.test"
 
-        minSdkVersion 16
+        minSdkVersion 14
         targetSdkVersion rootProject.ext.targetSdkVersion
 
         versionCode 1

--- a/scratchoff-sample/build.gradle
+++ b/scratchoff-sample/build.gradle
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId "com.jackpocket.scratchoff.test"
 
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion rootProject.ext.targetSdkVersion
 
         versionCode 1

--- a/scratchoff-sample/src/main/java/com/jackpocket/scratchoff/test/MainActivity.kt
+++ b/scratchoff-sample/src/main/java/com/jackpocket/scratchoff/test/MainActivity.kt
@@ -31,8 +31,8 @@ class MainActivity: AppCompatActivity(), ScratchoffController.ThresholdChangedLi
                 .setClearAnimationEnabled(true)
                 .setClearAnimationDuration(1, TimeUnit.SECONDS)
                 .setClearAnimationInterpolator(LinearInterpolator())
-                .setUsePreDrawForLayoutEnabled(true)
-                .setAttemptPostForIncompleteLayout(true)
+                .setUsePreDrawOverGlobalLayoutEnabled(true)
+                .setAttemptLastDitchPostForLayoutResolutionFailure(true)
                 // .setTouchRadiusPx(25)
                 // .setThresholdAccuracyQuality(Quality.LOW)
                 // .setThresholdTargetRegionsProvider({

--- a/scratchoff-sample/src/main/java/com/jackpocket/scratchoff/test/MainActivity.kt
+++ b/scratchoff-sample/src/main/java/com/jackpocket/scratchoff/test/MainActivity.kt
@@ -32,6 +32,7 @@ class MainActivity: AppCompatActivity(), ScratchoffController.ThresholdChangedLi
                 .setClearAnimationDuration(1, TimeUnit.SECONDS)
                 .setClearAnimationInterpolator(LinearInterpolator())
                 .setUsePreDrawForLayoutEnabled(true)
+                .setAttemptPostForIncompleteLayout(true)
                 // .setTouchRadiusPx(25)
                 // .setThresholdAccuracyQuality(Quality.LOW)
                 // .setThresholdTargetRegionsProvider({

--- a/scratchoff-sample/src/main/java/com/jackpocket/scratchoff/test/MainActivity.kt
+++ b/scratchoff-sample/src/main/java/com/jackpocket/scratchoff/test/MainActivity.kt
@@ -31,6 +31,7 @@ class MainActivity: AppCompatActivity(), ScratchoffController.ThresholdChangedLi
                 .setClearAnimationEnabled(true)
                 .setClearAnimationDuration(1, TimeUnit.SECONDS)
                 .setClearAnimationInterpolator(LinearInterpolator())
+                .setUsePreDrawForLayoutEnabled(true)
                 // .setTouchRadiusPx(25)
                 // .setThresholdAccuracyQuality(Quality.LOW)
                 // .setThresholdTargetRegionsProvider({

--- a/scratchoff/build.gradle
+++ b/scratchoff/build.gradle
@@ -11,7 +11,7 @@ android {
     buildToolsVersion = rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 14
         targetSdkVersion rootProject.ext.targetSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/scratchoff/build.gradle
+++ b/scratchoff/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     testImplementation "androidx.test.ext:junit:1.1.5"
     testImplementation "androidx.test:runner:1.5.2"
     testImplementation "androidx.test:core:1.5.0"
+    testImplementation "org.mockito.kotlin:mockito-kotlin:5.2.1"
     testImplementation "org.robolectric:robolectric:4.11.1"
 }
 

--- a/scratchoff/build.gradle
+++ b/scratchoff/build.gradle
@@ -11,7 +11,7 @@ android {
     buildToolsVersion = rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion rootProject.ext.targetSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchableLayoutDrawer.java
+++ b/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchableLayoutDrawer.java
@@ -6,6 +6,8 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
+import android.os.Handler;
+import android.os.Looper;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
@@ -386,14 +388,15 @@ public class ScratchableLayoutDrawer implements ScratchPathPointsAggregator, Ani
         view.requestLayout();
     }
 
-    private void triggerOrPostRunnableOnLaidOut(View view, Runnable runnable) {
+    protected void triggerOrPostRunnableOnLaidOut(View view, Runnable runnable) {
         if (runnable == null) {
             return;
         }
 
         if (attemptLastDitchPostForLayoutResolutionFailure) {
             if (view.getWidth() < 1 || view.getHeight() < 1) {
-                view.post(runnable);
+                Handler handler = new Handler(Looper.getMainLooper());
+                handler.post(runnable);
 
                 return;
             }

--- a/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchableLayoutDrawer.java
+++ b/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchableLayoutDrawer.java
@@ -58,8 +58,8 @@ public class ScratchableLayoutDrawer implements ScratchPathPointsAggregator, Ani
 
     private Long activeClearTag = 0L;
 
-    private boolean usePreDrawForLayoutEnabled = false;
-    private boolean attemptPostForIncompleteLayout = false;
+    private boolean usePreDrawOverGlobalLayoutEnabled = false;
+    private boolean attemptLastDitchPostForLayoutResolutionFailure = false;
 
     public ScratchableLayoutDrawer(Delegate delegate) {
         this.delegate = new WeakReference<>(delegate);
@@ -348,7 +348,7 @@ public class ScratchableLayoutDrawer implements ScratchPathPointsAggregator, Ani
     }
 
     private void deferRunnableUntilViewIsLaidOut(final View view, final Runnable runnable) {
-        if (usePreDrawForLayoutEnabled) {
+        if (usePreDrawOverGlobalLayoutEnabled) {
             view
                     .getViewTreeObserver()
                     .addOnPreDrawListener(
@@ -391,7 +391,7 @@ public class ScratchableLayoutDrawer implements ScratchPathPointsAggregator, Ani
             return;
         }
 
-        if (attemptPostForIncompleteLayout) {
+        if (attemptLastDitchPostForLayoutResolutionFailure) {
             if (view.getWidth() < 1 || view.getHeight() < 1) {
                 view.post(runnable);
 
@@ -417,15 +417,18 @@ public class ScratchableLayoutDrawer implements ScratchPathPointsAggregator, Ani
     }
 
     @SuppressWarnings("WeakerAccess")
-    public ScratchableLayoutDrawer setUsePreDrawForLayoutEnabled(boolean usePreDrawForLayoutEnabled) {
-        this.usePreDrawForLayoutEnabled = usePreDrawForLayoutEnabled;
+    public ScratchableLayoutDrawer setUsePreDrawOverGlobalLayoutEnabled(boolean usePreDrawOverGlobalLayoutEnabled) {
+        this.usePreDrawOverGlobalLayoutEnabled = usePreDrawOverGlobalLayoutEnabled;
 
         return this;
     }
 
     @SuppressWarnings("WeakerAccess")
-    public ScratchableLayoutDrawer setAttemptPostForIncompleteLayout(boolean attemptPostForIncompleteLayout) {
-        this.attemptPostForIncompleteLayout = attemptPostForIncompleteLayout;
+    public ScratchableLayoutDrawer setAttemptLastDitchPostForLayoutResolutionFailure(
+            boolean attemptLastDitchPostForLayoutResolutionFailure
+    ) {
+
+        this.attemptLastDitchPostForLayoutResolutionFailure = attemptLastDitchPostForLayoutResolutionFailure;
 
         return this;
     }

--- a/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchableLayoutDrawer.java
+++ b/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchableLayoutDrawer.java
@@ -6,6 +6,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.View;
@@ -376,10 +377,7 @@ public class ScratchableLayoutDrawer implements ScratchPathPointsAggregator, Ani
                                 @Override
                                 public void onGlobalLayout() {
                                     triggerOrPostRunnableOnLaidOut(view, runnable);
-
-                                    view
-                                            .getViewTreeObserver()
-                                            .removeOnGlobalLayoutListener(this);
+                                    removeGlobalLayoutListener(view, this);
                                 }
                             }
                     );
@@ -403,6 +401,19 @@ public class ScratchableLayoutDrawer implements ScratchPathPointsAggregator, Ani
         }
 
         runnable.run();
+    }
+
+    @SuppressWarnings({"deprecation", "RedundantSuppression"})
+    private void removeGlobalLayoutListener(View view, ViewTreeObserver.OnGlobalLayoutListener listener) {
+        if (Build.VERSION.SDK_INT < 16) {
+            view.getViewTreeObserver()
+                    .removeGlobalOnLayoutListener(listener);
+
+            return;
+        }
+
+        view.getViewTreeObserver()
+                .removeOnGlobalLayoutListener(listener);
     }
 
     @SuppressWarnings("WeakerAccess")

--- a/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchoffController.java
+++ b/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchoffController.java
@@ -80,6 +80,7 @@ public class ScratchoffController implements OnTouchListener,
     private boolean stateRestorationEnabled;
 
     private boolean usePreDrawForLayoutEnabled = false;
+    private boolean attemptPostForIncompleteLayout = false;
 
     /**
      * Create a new {@link ScratchoffController} instance targeting a scratchable layout.
@@ -154,7 +155,8 @@ public class ScratchoffController implements OnTouchListener,
         return new ScratchableLayoutDrawer(this)
                 .setClearAnimationDurationMs(clearAnimationDurationMs)
                 .setClearAnimationInterpolator(clearAnimationInterpolator)
-                .setUsePreDrawForLayoutEnabled(usePreDrawForLayoutEnabled);
+                .setUsePreDrawForLayoutEnabled(usePreDrawForLayoutEnabled)
+                .setAttemptPostForIncompleteLayout(attemptPostForIncompleteLayout);
     }
 
     protected ScratchoffThresholdProcessor createThresholdProcessor() {
@@ -480,6 +482,20 @@ public class ScratchoffController implements OnTouchListener,
      */
     public ScratchoffController setUsePreDrawForLayoutEnabled(boolean usePreDrawForLayoutEnabled) {
         this.usePreDrawForLayoutEnabled = usePreDrawForLayoutEnabled;
+
+        return this;
+    }
+
+    /**
+     * Set whether or not to attempt one final last-ditch {@link View#post} when determining the
+     * layout sizing of our {@link #layoutDrawer} if our {@link android.view.ViewTreeObserver}
+     * attempt ran while the {@link #scratchableLayout}'s width or height is still zero.
+     * This is in attempt to fix #19 caused by the width or height of the View being
+     * zero when attempting to create the scratchable {@link Bitmap} instances.
+     * The default for this value is false for the original (crashing) behavior.
+     */
+    public ScratchoffController setAttemptPostForIncompleteLayout(boolean attemptPostForIncompleteLayout) {
+        this.attemptPostForIncompleteLayout = attemptPostForIncompleteLayout;
 
         return this;
     }

--- a/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchoffController.java
+++ b/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchoffController.java
@@ -79,8 +79,8 @@ public class ScratchoffController implements OnTouchListener,
     private final LinkedBlockingQueue<ScratchPathPoint> history = new LinkedBlockingQueue<ScratchPathPoint>();
     private boolean stateRestorationEnabled;
 
-    private boolean usePreDrawForLayoutEnabled = false;
-    private boolean attemptPostForIncompleteLayout = false;
+    private boolean usePreDrawOverGlobalLayoutEnabled = false;
+    private boolean attemptLastDitchPostForLayoutResolutionFailure = false;
 
     /**
      * Create a new {@link ScratchoffController} instance targeting a scratchable layout.
@@ -155,8 +155,8 @@ public class ScratchoffController implements OnTouchListener,
         return new ScratchableLayoutDrawer(this)
                 .setClearAnimationDurationMs(clearAnimationDurationMs)
                 .setClearAnimationInterpolator(clearAnimationInterpolator)
-                .setUsePreDrawForLayoutEnabled(usePreDrawForLayoutEnabled)
-                .setAttemptPostForIncompleteLayout(attemptPostForIncompleteLayout);
+                .setUsePreDrawOverGlobalLayoutEnabled(usePreDrawOverGlobalLayoutEnabled)
+                .setAttemptLastDitchPostForLayoutResolutionFailure(attemptLastDitchPostForLayoutResolutionFailure);
     }
 
     protected ScratchoffThresholdProcessor createThresholdProcessor() {
@@ -480,8 +480,8 @@ public class ScratchoffController implements OnTouchListener,
      * zero when attempting to create the scratchable {@link Bitmap} instances.
      * The default for this value is false for the original (crashing) behavior.
      */
-    public ScratchoffController setUsePreDrawForLayoutEnabled(boolean usePreDrawForLayoutEnabled) {
-        this.usePreDrawForLayoutEnabled = usePreDrawForLayoutEnabled;
+    public ScratchoffController setUsePreDrawOverGlobalLayoutEnabled(boolean usePreDrawOverGlobalLayoutEnabled) {
+        this.usePreDrawOverGlobalLayoutEnabled = usePreDrawOverGlobalLayoutEnabled;
 
         return this;
     }
@@ -494,8 +494,11 @@ public class ScratchoffController implements OnTouchListener,
      * zero when attempting to create the scratchable {@link Bitmap} instances.
      * The default for this value is false for the original (crashing) behavior.
      */
-    public ScratchoffController setAttemptPostForIncompleteLayout(boolean attemptPostForIncompleteLayout) {
-        this.attemptPostForIncompleteLayout = attemptPostForIncompleteLayout;
+    public ScratchoffController setAttemptLastDitchPostForLayoutResolutionFailure(
+            boolean attemptLastDitchPostForLayoutResolutionFailure
+    ) {
+
+        this.attemptLastDitchPostForLayoutResolutionFailure = attemptLastDitchPostForLayoutResolutionFailure;
 
         return this;
     }

--- a/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchoffController.java
+++ b/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchoffController.java
@@ -487,9 +487,10 @@ public class ScratchoffController implements OnTouchListener,
     }
 
     /**
-     * Set whether or not to attempt one final last-ditch {@link View#post} when determining the
-     * layout sizing of our {@link #layoutDrawer} if our {@link android.view.ViewTreeObserver}
-     * attempt ran while the {@link #scratchableLayout}'s width or height is still zero.
+     * Set whether or not to attempt one final last-ditch {@link android.os.Handler#post} on
+     * the main Thread when determining the layout sizing of our {@link #layoutDrawer} if
+     * our {@link android.view.ViewTreeObserver} attempt ran while the {@link #scratchableLayout}'s
+     * width or height is still zero.
      * This is in attempt to fix #19 caused by the width or height of the View being
      * zero when attempting to create the scratchable {@link Bitmap} instances.
      * The default for this value is false for the original (crashing) behavior.

--- a/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchoffController.java
+++ b/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchoffController.java
@@ -79,6 +79,8 @@ public class ScratchoffController implements OnTouchListener,
     private final LinkedBlockingQueue<ScratchPathPoint> history = new LinkedBlockingQueue<ScratchPathPoint>();
     private boolean stateRestorationEnabled;
 
+    private boolean usePreDrawForLayoutEnabled = false;
+
     /**
      * Create a new {@link ScratchoffController} instance targeting a scratchable layout.
      */
@@ -151,7 +153,8 @@ public class ScratchoffController implements OnTouchListener,
     protected ScratchableLayoutDrawer createLayoutDrawer() {
         return new ScratchableLayoutDrawer(this)
                 .setClearAnimationDurationMs(clearAnimationDurationMs)
-                .setClearAnimationInterpolator(clearAnimationInterpolator);
+                .setClearAnimationInterpolator(clearAnimationInterpolator)
+                .setUsePreDrawForLayoutEnabled(usePreDrawForLayoutEnabled);
     }
 
     protected ScratchoffThresholdProcessor createThresholdProcessor() {
@@ -463,6 +466,20 @@ public class ScratchoffController implements OnTouchListener,
      */
     public ScratchoffController setStateRestorationEnabled(boolean stateRestorationEnabled) {
         this.stateRestorationEnabled = stateRestorationEnabled;
+
+        return this;
+    }
+
+    /**
+     * Set whether or not to use the new {@link android.view.ViewTreeObserver.OnPreDrawListener}
+     * code paths to determine the layout sizing, instead of the original
+     * {@link android.view.ViewTreeObserver.OnGlobalLayoutListener} implementation.
+     * This is in attempt to fix #19 caused by the width or height of the View being
+     * zero when attempting to create the scratchable {@link Bitmap} instances.
+     * The default for this value is false for the original (crashing) behavior.
+     */
+    public ScratchoffController setUsePreDrawForLayoutEnabled(boolean usePreDrawForLayoutEnabled) {
+        this.usePreDrawForLayoutEnabled = usePreDrawForLayoutEnabled;
 
         return this;
     }

--- a/scratchoff/src/test/java/com/jackpocket/scratchoff/ScratchoffControllerTests.kt
+++ b/scratchoff/src/test/java/com/jackpocket/scratchoff/ScratchoffControllerTests.kt
@@ -407,6 +407,17 @@ class ScratchoffControllerTests {
         controller.setTouchRadiusPx(0)
     }
 
+    fun testCreateLayoutDrawerWithFix19ChangesEnabled() {
+        // This is purely to ensure the new ScratchoffController code paths run under our
+        // test environment even though they will be removed in a future release.
+        // We're not going to actively expose these temporary variables, so there will
+        // be no actual assertions made in this test, which will ultimately be removed.
+        val controller = ScratchoffController(mockScratchableLayout)
+        controller.setUsePreDrawOverGlobalLayoutEnabled(true)
+        controller.setAttemptLastDitchPostForLayoutResolutionFailure(true)
+        controller.createLayoutDrawer()
+    }
+
     private class LoggingThresholdChangedListener: ScratchoffController.ThresholdChangedListener {
 
         var threshold: Float = 0f


### PR DESCRIPTION
This PR consists of two separate changes which are backwards-compatible with the original implementation and are disabled by default.

* Attempt to use a `ViewTreeObserver.OnPreDrawListener` instead of the original `ViewTreeObserver.OnGlobalLayoutListener` when deferring the `Runnable` instances until the `View` has been laid out. This behavior is enabled by calling `setUsePreDrawForLayoutEnabled` with a value of `true` on the `ScratchoffController` instance.
* Attempt a last-ditch `post` on the `View` with the laid-out-requiring `Runnable` when the `View` size is still zero after `onPreDraw` or `onGlobalLayout` are triggered. This behavior is enabled by calling `setAttemptPostForIncompleteLayout` with a value of `true` on the `ScratchoffController` instance.
