### PR TITLE
Fixes #19 by continuing to listen for layout/pre-draw events until a valid size is discovered, or the drawer is destroyed

### DIFF
--- a/scratchoff-sample/src/main/java/com/jackpocket/scratchoff/test/MainActivity.kt
+++ b/scratchoff-sample/src/main/java/com/jackpocket/scratchoff/test/MainActivity.kt
@@ -35,7 +35,8 @@ class MainActivity: AppCompatActivity(),
             .setClearAnimationDuration(1, TimeUnit.SECONDS)
             .setClearAnimationInterpolator(LinearInterpolator())
             .setUsePreDrawOverGlobalLayoutEnabled(true)
-            .setAttemptLastDitchPostForLayoutResolutionFailure(true)
+            // .setAttemptLastDitchPostForLayoutResolutionFailure(true)
+            .setKeepListeningForDrawUntilValidSizeDiscovered(true)
             // .setTouchRadiusPx(25)
             // .setThresholdAccuracyQuality(Quality.LOW)
             // .setThresholdTargetRegionsProvider({

--- a/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchoffController.java
+++ b/scratchoff/src/main/java/com/jackpocket/scratchoff/ScratchoffController.java
@@ -81,6 +81,7 @@ public class ScratchoffController implements OnTouchListener,
 
     private boolean usePreDrawOverGlobalLayoutEnabled = false;
     private boolean attemptLastDitchPostForLayoutResolutionFailure = false;
+    private boolean keepListeningForDrawUntilValidSizeDiscovered = false;
 
     /**
      * Create a new {@link ScratchoffController} instance targeting a scratchable layout.
@@ -157,7 +158,8 @@ public class ScratchoffController implements OnTouchListener,
             .setClearAnimationDurationMs(clearAnimationDurationMs)
             .setClearAnimationInterpolator(clearAnimationInterpolator)
             .setUsePreDrawOverGlobalLayoutEnabled(usePreDrawOverGlobalLayoutEnabled)
-            .setAttemptLastDitchPostForLayoutResolutionFailure(attemptLastDitchPostForLayoutResolutionFailure);
+            .setAttemptLastDitchPostForLayoutResolutionFailure(attemptLastDitchPostForLayoutResolutionFailure)
+            .setKeepListeningForDrawUntilValidSizeDiscovered(keepListeningForDrawUntilValidSizeDiscovered);
     }
 
     protected ScratchoffThresholdProcessor createThresholdProcessor() {
@@ -513,6 +515,24 @@ public class ScratchoffController implements OnTouchListener,
     ) {
 
         this.attemptLastDitchPostForLayoutResolutionFailure = attemptLastDitchPostForLayoutResolutionFailure;
+
+        return this;
+    }
+
+    /**
+     * Set whether or not to continue listening for {@link android.view.ViewTreeObserver.OnGlobalLayoutListener}
+     * or {@link android.view.ViewTreeObserver.OnPreDrawListener} events when the callbacks are
+     * triggered with a size that is invalid for initialization. Setting this to true will override the
+     * behavior for {@link setAttemptLastDitchPostForLayoutResolutionFailure}.
+     * This is in attempt to fix #19 caused by the width or height of the View being
+     * zero when attempting to create the scratchable {@link Bitmap} instances.
+     * The default for this value is false for the original (crashing) behavior.
+     */
+    public ScratchoffController setKeepListeningForDrawUntilValidSizeDiscovered(
+        boolean keepListeningForDrawUntilValidSizeDiscovered
+    ) {
+
+        this.keepListeningForDrawUntilValidSizeDiscovered = keepListeningForDrawUntilValidSizeDiscovered;
 
         return this;
     }


### PR DESCRIPTION
Fixes #19 by continuing to listen for `ViewTreeObserver.OnGlobalLayoutListener`/`ViewTreeObserver.OnPreDrawListener` events until a valid size (width and height both greater than 0) is discovered, or the drawer is destroyed (via `ScratchoffController#onDestroy` -> `ScratchaboutLayoutDrawer#destroy`).

To enable this new behavior, call `setKeepListeningForDrawUntilValidSizeDiscovered` with a value of `true`. Note that this will override the configuration of `setAttemptLastDitchPostForLayoutResolutionFailure` introduced with 3.0.0.

Assuming this solves #19 at scale, and doesn't introduce any new issues, it will become part of the default behavior in 4.x.